### PR TITLE
Add project CRUD API and admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ yarn dev
 bun run dev
 ```
 
+## Server API & Admin
+
+This project exposes CRUD endpoints under `/api/projects` that persist data to `server/data/projects.json`.
+
+To protect the admin interface set an environment variable `ADMIN_PASSWORD` before starting the server. A simple back-office is available at `/admin` once authenticated.
+
+### Example
+
+```bash
+ADMIN_PASSWORD=mySecret bun run dev
+```
+
+After starting visit `http://localhost:3000/admin` to manage projects.
+
 ## Production
 
 Build the application for production:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,9 @@ export default defineNuxtConfig({
   nitro: {
     preset: "vercel",
   },
+  runtimeConfig: {
+    ADMIN_PASSWORD: process.env.ADMIN_PASSWORD || "admin",
+  },
   compatibilityDate: "2024-11-01",
   modules: ["@nuxtjs/tailwindcss"],
   devtools: { enabled: true },

--- a/pages/admin.vue
+++ b/pages/admin.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+const password = ref('');
+const isAuthed = ref(false);
+const projects = ref([]);
+
+const fetchProjects = async () => {
+  projects.value = await $fetch('/api/projects');
+};
+
+onMounted(() => {
+  if (localStorage.getItem('admin-authed') === 'true') {
+    isAuthed.value = true;
+    fetchProjects();
+  }
+});
+
+const login = async () => {
+  const res = await $fetch('/api/auth', { method: 'POST', body: { password: password.value } });
+  if (res.success) {
+    isAuthed.value = true;
+    localStorage.setItem('admin-authed', 'true');
+    fetchProjects();
+  } else {
+    alert('Wrong password');
+  }
+};
+
+const newProject = ref({
+  title: '',
+  category: '',
+  image: '',
+  description: '',
+  shortTalk: '',
+  video: '',
+  images: ''
+});
+
+const createProject = async () => {
+  const payload = { ...newProject.value, images: newProject.value.images.split(',').map((v: string) => v.trim()).filter(Boolean) };
+  await $fetch('/api/projects', { method: 'POST', body: payload });
+  Object.assign(newProject.value, { title: '', category: '', image: '', description: '', shortTalk: '', video: '', images: '' });
+  fetchProjects();
+};
+
+const updateProject = async (p: any) => {
+  const payload = { ...p, images: typeof p.images === 'string' ? p.images.split(',').map((v: string) => v.trim()).filter(Boolean) : p.images };
+  await $fetch(`/api/projects/${p.id}`, { method: 'PUT', body: payload });
+  fetchProjects();
+};
+
+const deleteProject = async (id: number) => {
+  await $fetch(`/api/projects/${id}`, { method: 'DELETE' });
+  fetchProjects();
+};
+</script>
+
+<template>
+  <section class="p-8 text-white max-w-3xl mx-auto">
+    <div v-if="!isAuthed" class="space-y-4">
+      <h1 class="text-2xl font-bold">Admin Login</h1>
+      <input v-model="password" type="password" placeholder="Password" class="p-2 text-black w-full" />
+      <button @click="login" class="bg-blue-500 px-4 py-2 rounded text-white">Login</button>
+    </div>
+
+    <div v-else>
+      <h1 class="text-2xl font-bold mb-4">Manage Projects</h1>
+
+      <div class="mb-8 space-y-2">
+        <h2 class="font-semibold">Add New Project</h2>
+        <input v-model="newProject.title" placeholder="Title" class="p-1 text-black w-full" />
+        <input v-model="newProject.category" placeholder="Category" class="p-1 text-black w-full" />
+        <input v-model="newProject.image" placeholder="Image" class="p-1 text-black w-full" />
+        <input v-model="newProject.description" placeholder="Description" class="p-1 text-black w-full" />
+        <input v-model="newProject.shortTalk" placeholder="Short Talk" class="p-1 text-black w-full" />
+        <input v-model="newProject.video" placeholder="Video" class="p-1 text-black w-full" />
+        <input v-model="newProject.images" placeholder="Images (comma separated)" class="p-1 text-black w-full" />
+        <button @click="createProject" class="bg-green-600 px-3 py-1 rounded text-white">Create</button>
+      </div>
+
+      <div v-for="p in projects" :key="p.id" class="border-b border-gray-600 pb-4 mb-4 space-y-1">
+        <input v-model="p.title" class="p-1 text-black w-full" />
+        <input v-model="p.category" class="p-1 text-black w-full" />
+        <input v-model="p.image" class="p-1 text-black w-full" />
+        <input v-model="p.description" class="p-1 text-black w-full" />
+        <input v-model="p.shortTalk" class="p-1 text-black w-full" />
+        <input v-model="p.video" class="p-1 text-black w-full" />
+        <input v-model="p.images" class="p-1 text-black w-full" />
+        <div class="space-x-2 mt-2">
+          <button @click="updateProject(p)" class="bg-yellow-600 px-3 py-1 rounded text-white">Save</button>
+          <button @click="deleteProject(p.id)" class="bg-red-600 px-3 py-1 rounded text-white">Delete</button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -1,76 +1,23 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed } from "vue";
 
-const projectCategories = [
-  {
-    category: "Game Development",
-    projects: [
-      {
-        title: "12TailsOnline Server",
-        image: "/12TailsOnline/12TailsPoster.jpg",
-        description: "A multiplayer online game server.",
-        shortTalk:
-          "Hi there! I'm just developing a game server for 12TailsOnline for learning something new, and I'm loving this game since it published in 2011. I never find the game make me fun and happy like this game. So I decided to make a server for this game. I hope it will be the Dream server for every one because I developed it with my love <3.",
-        video: "https://www.youtube.com/embed/P8xABk6rdns",
-        images: [
-          "/12TailsOnline/1.png",
-          "/12TailsOnline/2.png",
-          "/12TailsOnline/3.png",
-          "/12TailsOnline/4.png",
-          "/12TailsOnline/5.png",
-        ],
-      },
-      {
-        title: "HeroBois",
-        image: "/HeroBois.png",
-        description: "An educational math-based game.",
-        shortTalk: "A fun game designed to improve skill in rouge-like games",
-        video: "https://www.youtube.com/embed/MbqKK-7Fmko",
-      },
-      {
-        title: "VR Experiment",
-        image: "/VrGame.png",
-        description: "A virtual reality game experiment.",
-        shortTalk:
-          "Exploring the future of gaming with VR, providing an immersive experience.",
-        video: "https://www.youtube.com/embed/k0ZGAGonSXU",
-      },
-    ],
-  },
-  {
-    category: "Web Development",
-    projects: [
-      {
-        title: "AZ Mirror",
-        image: "/AZMirror.png",
-        description: "3D model viewer for startups.",
-        shortTalk:
-          "A web app that allows users to preview and interact with 3D models in real time.",
-        video: "https://www.youtube.com/embed/example-video",
-      },
-      {
-        title: "Trading Reward",
-        image: "/TradingReward.png",
-        description: "A web platform for tracking rewards.",
-        shortTalk:
-          "Helping businesses manage and track their customer reward programs efficiently.",
-        video: "",
-      },
-    ],
-  },
-  {
-    category: "Mobile Applications",
-    projects: [
-      {
-        title: "TrackIt",
-        image: "/TrackIt.png",
-        description: "A mobile app for tracking expenses.",
-        shortTalk: "A simple and intuitive app for managing personal finances.",
-        video: "https://www.youtube.com/embed/7nfjNrI96BA",
-      },
-    ],
-  },
-];
+const { data: projects } = await useFetch("/api/projects");
+
+const projectCategories = computed(() => {
+  const groups: Record<string, any[]> = {};
+  if (projects.value) {
+    for (const project of projects.value as any[]) {
+      if (!groups[project.category]) {
+        groups[project.category] = [];
+      }
+      groups[project.category].push(project);
+    }
+  }
+  return Object.entries(groups).map(([category, projects]) => ({
+    category,
+    projects,
+  }));
+});
 
 // Store the currently selected project for the modal
 const selectedProject = ref(null);

--- a/server/api/auth.post.ts
+++ b/server/api/auth.post.ts
@@ -1,0 +1,8 @@
+import { readBody } from 'h3';
+
+export default defineEventHandler(async (event) => {
+  const { password } = await readBody(event);
+  const config = useRuntimeConfig();
+  const success = password === config.ADMIN_PASSWORD;
+  return { success };
+});

--- a/server/api/projects/[id].delete.ts
+++ b/server/api/projects/[id].delete.ts
@@ -1,0 +1,13 @@
+import { readProjects, writeProjects } from '../../utils/projects';
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id);
+  const projects = await readProjects();
+  const index = projects.findIndex((p: any) => p.id === id);
+  if (index === -1) {
+    throw createError({ statusCode: 404, statusMessage: 'Project not found' });
+  }
+  projects.splice(index, 1);
+  await writeProjects(projects);
+  return { success: true };
+});

--- a/server/api/projects/[id].get.ts
+++ b/server/api/projects/[id].get.ts
@@ -1,0 +1,7 @@
+import { readProjects } from '../../utils/projects';
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id);
+  const projects = await readProjects();
+  return projects.find((p: any) => p.id === id) || null;
+});

--- a/server/api/projects/[id].put.ts
+++ b/server/api/projects/[id].put.ts
@@ -1,0 +1,15 @@
+import { readBody } from 'h3';
+import { readProjects, writeProjects } from '../../utils/projects';
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id);
+  const body = await readBody(event);
+  const projects = await readProjects();
+  const index = projects.findIndex((p: any) => p.id === id);
+  if (index === -1) {
+    throw createError({ statusCode: 404, statusMessage: 'Project not found' });
+  }
+  projects[index] = { ...projects[index], ...body, id };
+  await writeProjects(projects);
+  return projects[index];
+});

--- a/server/api/projects/index.get.ts
+++ b/server/api/projects/index.get.ts
@@ -1,0 +1,5 @@
+import { readProjects } from '../../utils/projects';
+
+export default defineEventHandler(async () => {
+  return await readProjects();
+});

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -1,0 +1,11 @@
+import { readBody } from 'h3';
+import { readProjects, writeProjects } from '../../utils/projects';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  const projects = await readProjects();
+  const newProject = { id: Date.now(), ...body };
+  projects.push(newProject);
+  await writeProjects(projects);
+  return newProject;
+});

--- a/server/data/projects.json
+++ b/server/data/projects.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": 1,
+    "category": "Game Development",
+    "title": "12TailsOnline Server",
+    "image": "/12TailsOnline/12TailsPoster.jpg",
+    "description": "A multiplayer online game server.",
+    "shortTalk": "Hi there! I'm just developing a game server for 12TailsOnline for learning something new, and I'm loving this game since it published in 2011. I never find the game make me fun and happy like this game. So I decided to make a server for this game. I hope it will be the Dream server for every one because I developed it with my love <3.",
+    "video": "https://www.youtube.com/embed/P8xABk6rdns",
+    "images": [
+      "/12TailsOnline/1.png",
+      "/12TailsOnline/2.png",
+      "/12TailsOnline/3.png",
+      "/12TailsOnline/4.png",
+      "/12TailsOnline/5.png"
+    ]
+  },
+  {
+    "id": 2,
+    "category": "Game Development",
+    "title": "HeroBois",
+    "image": "/HeroBois.png",
+    "description": "An educational math-based game.",
+    "shortTalk": "A fun game designed to improve skill in rouge-like games",
+    "video": "https://www.youtube.com/embed/MbqKK-7Fmko",
+    "images": []
+  },
+  {
+    "id": 3,
+    "category": "Game Development",
+    "title": "VR Experiment",
+    "image": "/VrGame.png",
+    "description": "A virtual reality game experiment.",
+    "shortTalk": "Exploring the future of gaming with VR, providing an immersive experience.",
+    "video": "https://www.youtube.com/embed/k0ZGAGonSXU",
+    "images": []
+  },
+  {
+    "id": 4,
+    "category": "Web Development",
+    "title": "AZ Mirror",
+    "image": "/AZMirror.png",
+    "description": "3D model viewer for startups.",
+    "shortTalk": "A web app that allows users to preview and interact with 3D models in real time.",
+    "video": "https://www.youtube.com/embed/example-video",
+    "images": []
+  },
+  {
+    "id": 5,
+    "category": "Web Development",
+    "title": "Trading Reward",
+    "image": "/TradingReward.png",
+    "description": "A web platform for tracking rewards.",
+    "shortTalk": "Helping businesses manage and track their customer reward programs efficiently.",
+    "video": "",
+    "images": []
+  },
+  {
+    "id": 6,
+    "category": "Mobile Applications",
+    "title": "TrackIt",
+    "image": "/TrackIt.png",
+    "description": "A mobile app for tracking expenses.",
+    "shortTalk": "A simple and intuitive app for managing personal finances.",
+    "video": "https://www.youtube.com/embed/7nfjNrI96BA",
+    "images": []
+  }
+]

--- a/server/utils/projects.ts
+++ b/server/utils/projects.ts
@@ -1,0 +1,17 @@
+import { readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+const dataPath = join(process.cwd(), 'server', 'data', 'projects.json');
+
+export async function readProjects() {
+  try {
+    const data = await readFile(dataPath, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
+}
+
+export async function writeProjects(projects: any) {
+  await writeFile(dataPath, JSON.stringify(projects, null, 2));
+}


### PR DESCRIPTION
## Summary
- add runtime config for admin password
- create CRUD endpoints and JSON persistence
- fetch project data from API in the projects page
- add admin page with simple auth and project management forms
- document how to run the server and admin panel

## Testing
- `bun x eslint .` *(fails: GET https://registry.npmjs.org/eslint - 403)*

------
https://chatgpt.com/codex/tasks/task_e_6846d75d1714832da0a886a0c8c771ec